### PR TITLE
Add a new feature to the Z command so the device returns the current timestamp when used without any option (i. e., Z[CR]).

### DIFF
--- a/doc/1.-Command-List.md
+++ b/doc/1.-Command-List.md
@@ -48,11 +48,12 @@ CMD | SUPPORT | SYNTAX                 | DESCRIPTION
 'N' |   YES   |   N[CR]                | Gets serial number of the hardware.
     |    +    |   Nxxxx[CR]            | Sets serial number of the hardware to xxxx,
     |         |                        | where the new serial number xxxx is a hex value.
-'Z' |   YES   |   Zn[CR]               | Set time stamp ON/OFF for received frames only.
+'Z' |   YES   |   Zn[CR]               | Sets timestamp ON/OFF for received frames only.
     |         |                        | Z0 No timestamp
     |         |                        | Z1 Millisecond timestamp
     |    +    |                        | Z2 Microsecond timestamp
-'z' |   YES+  |   znxyy[CR]            | Sets the reporting mechanism.
+    |    +    |   Z[CR]                | Gets current timestamp
+'z' |   YES+  |   znxyy[CR]            | Sets the reporting mechanism,
     |         |                        | where x and yy are hex values.
 'Q' |   YES   |   Qn[CR]               | Sets auto startup feature ON/OFF (from power on). 
     |         |                        | Q0 Auto startup off
@@ -624,12 +625,28 @@ Returns:
 - CR for OK or BELL for ERROR.
 
 
+## Z[CR]
+
+Gets current timestamp.
+
+Precondition:
+- Timestamp should be enabled.
+
+Example:
+- `Z[CR]`
+
+Gets timestamp.
+
+Returns:
+- `Zxxxx[CR]` (ms) or `Zxxxxxxxx[CR]` (us) for OK or BELL for ERROR.
+
+
 ## Zn[CR]
 
 Sets timestamp on/off for received frames only.
 
 Unlike CAN232 or CANUSB, this command itself does not write non-volatile memory.
-The time stamp mode is stored in non-volatile memory when auto startup feature is enabled by `Q` command.
+The timestamp mode is stored in non-volatile memory when auto startup feature is enabled by `Q` command.
 
 - `Z0`  Timestamp off
 - `Z1`  Milli second timestamp (2 bytes in hex, reset to 0 at 0xEA60 ms = 60,000 ms)
@@ -641,13 +658,13 @@ Precondition:
 Example 1:
 - `Z0[CR]`
 
-Turns off the time stamp feature (default).
+Turns off the timestamp feature (default).
 
 Example 2:
 - `Z2[CR]`
 
-Turns on the micro second time stamp feature.
-Four bytes time stamp is attached behind data bytes of the frame.
+Turns on the micro second timestamp feature.
+Four bytes timestamp is attached behind data bytes of the frame.
 
 Returns:
 - CR for OK or BELL for ERROR.
@@ -657,7 +674,7 @@ Returns:
 
 Sets up the reporting mechanism.
 
-- `n`   Time stamp mode corresponding to `Z` command
+- `n`   Timestamp mode corresponding to `Z` command
 - `x`   Reserved
 - `yy`  A hex value with 8 bits:
 
@@ -676,21 +693,21 @@ Precondition:
 Example 1:
 - `z0001[CR]`
 
-Turns on Rx frame reporting without time stamp or ESI (default).
+Turns on Rx frame reporting without timestamp or ESI (default).
 
 Example 2:
 - `z1012[CR]`
 
-Turns on Tx event with milli second time stamp and ESI.
-The ESI bit is placed behind time stamp and `0` is used for error active and `1` for error passive.
+Turns on Tx event with milli second timestamp and ESI.
+The ESI bit is placed behind timestamp and `0` is used for error active and `1` for error passive.
 No Rx frame is reported in this setting.
 
 Returns:
 - CR for OK or BELL for ERROR.
 
 Note:
-- The milli second time stamp is taken after the CAN frame transmission is complete, 
-  while the micro second time stamp is taken at the start of CAN frame.
+- The milli second timestamp is taken after the CAN frame transmission is complete, 
+  while the micro second timestamp is taken at the start of CAN frame.
 - This command is mutually exclusive with the `Z` command.
   Any settings made by this command will be overwritten by the one in the command or by default.
 

--- a/test/test_loopback.py
+++ b/test/test_loopback.py
@@ -313,7 +313,7 @@ class LoopbackTestCase(unittest.TestCase):
         if crnt_time_us > last_time_us:
             diff_time_us = crnt_time_us - last_time_us
         else:
-            diff_time_us = (0x100000000 + crnt_time_us) - last_time_us
+            diff_time_us = (3600000000 + crnt_time_us) - last_time_us
 
         # Proving 2% accuracy. 600ms should be acceptable for USB latency.
         self.assertLess(abs(sleep_time_us - diff_time_us), 600 * 1000)
@@ -341,6 +341,33 @@ class LoopbackTestCase(unittest.TestCase):
         else:
             rx_timestamp = rx_data[len(b"\rt03F0"):len(b"\rt03F0") + 8]
         self.assertEqual(tx_timestamp, rx_timestamp)
+        self.dut.send(b"C\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+
+
+    def test_timestamp_consistency(self):
+        #self.dut.print_on = True
+
+        # Compare timestamp for a Z[CR] command and for a received CAN frame
+        self.dut.send(b"S8\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"z2001\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"=\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"Z\rt03F0\r")
+        rx_data = self.dut.receive() + self.dut.receive()
+        last_timestamp = rx_data[len(b"Z"):len(b"Z") + 8]
+        last_time_us = int(last_timestamp.decode(), 16)
+        crnt_timestamp = rx_data[len(b"ZXXXXXXXX\rz\rt03F0"):len(b"ZXXXXXXXX\rz\rt03F0") + 8]
+        crnt_time_us = int(crnt_timestamp.decode(), 16)
+        if crnt_time_us > last_time_us:
+            diff_time_us = crnt_time_us - last_time_us
+        else:
+            diff_time_us = (3600000000 + crnt_time_us) - last_time_us
+
+        # Difference should be less than time to send the frame (~50us) + main loop cycle (~100us)
+        self.assertLess(diff_time_us, 200)
         self.dut.send(b"C\r")
         self.assertEqual(self.dut.receive(), b"\r")
 

--- a/test/test_slcan.py
+++ b/test/test_slcan.py
@@ -325,6 +325,30 @@ class SlcanTestCase(unittest.TestCase):
 
 
     def test_Z_command(self):
+        # Without option
+        # check response to Z with timestamp disabled
+        self.dut.send(b"Z0\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"Z\r")
+        self.assertEqual(self.dut.receive(), b"\a")
+
+        # check response to Z with ms timestamp
+        self.dut.send(b"Z1\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"Z\r")
+        rx_data = self.dut.receive()
+        self.assertEqual(len(rx_data), len(b"Zxxxx\r"))
+        self.assertEqual(rx_data[0], b"Zxxxx\r"[0])
+
+        # check response to Z with us timestamp
+        self.dut.send(b"Z2\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"Z\r")
+        rx_data = self.dut.receive()
+        self.assertEqual(len(rx_data), len(b"Zxxxxxxxx\r"))
+        self.assertEqual(rx_data[0], b"Zxxxxxxxx\r"[0])
+
+        # With option
         # check response to Z with CAN port closed
         for idx in range(0, 10):
             cmd = "Z" + str(idx) + "\r"
@@ -355,8 +379,6 @@ class SlcanTestCase(unittest.TestCase):
         self.assertEqual(self.dut.receive(), b"\r")
 
         # invalid format
-        self.dut.send(b"Z\r")
-        self.assertEqual(self.dut.receive(), b"\a")
         self.dut.send(b"Z00\r")
         self.assertEqual(self.dut.receive(), b"\a")
         self.dut.send(b"ZG\r")

--- a/usb2canfdv1-fw/Slcan/Inc/slcan.h
+++ b/usb2canfdv1-fw/Slcan/Inc/slcan.h
@@ -80,6 +80,8 @@ extern uint16_t slcan_report_reg;
 // Prototypes
 int32_t slcan_generate_rx_frame(uint8_t *buf, FDCAN_RxHeaderTypeDef *frame_header, uint8_t *frame_data);
 int32_t slcan_generate_tx_event(uint8_t *buf, FDCAN_TxEventFifoTypeDef *tx_event, uint8_t *frame_data);
+uint16_t slcan_get_timestamp_ms(void);
+uint32_t slcan_get_timestamp_us_from_tim3(uint16_t tim3_us);
 void slcan_set_timestamp_mode(enum slcan_timestamp_mode mode);
 void slcan_set_report_mode(uint16_t reg);
 enum slcan_timestamp_mode slcan_get_timestamp_mode(void);

--- a/usb2canfdv1-fw/Slcan/Src/parser.c
+++ b/usb2canfdv1-fw/Slcan/Src/parser.c
@@ -539,6 +539,47 @@ void slcan_parse_str_set_bitrate(uint8_t *buf, uint8_t len)
 // Set report mode
 void slcan_parse_str_report_mode(uint8_t *buf, uint8_t len)
 {
+    // Get timestamp
+    if (buf[0] == 'Z' && len == 1)
+    {
+        // Check timestamp mode
+        if (slcan_timestamp_mode == SLCAN_TIMESTAMP_MILLI)
+        {
+        	uint8_t* tmsstr = buf_get_cdc_dest();
+        	uint16_t timestamp_ms = slcan_get_timestamp_ms();
+
+        	tmsstr[0] = 'Z';
+        	tmsstr[1] = slcan_nibble_to_ascii[(timestamp_ms >> 12) & 0xF];
+        	tmsstr[2] = slcan_nibble_to_ascii[(timestamp_ms >> 8) & 0xF];
+        	tmsstr[3] = slcan_nibble_to_ascii[(timestamp_ms >> 4) & 0xF];
+        	tmsstr[4] = slcan_nibble_to_ascii[timestamp_ms & 0xF];
+        	tmsstr[5] = '\r';
+            buf_comit_cdc_dest(6);
+        }
+        else if (slcan_timestamp_mode == SLCAN_TIMESTAMP_MICRO)
+        {
+        	uint8_t* tmsstr = buf_get_cdc_dest();
+        	uint32_t timestamp_us = slcan_get_timestamp_us_from_tim3(TIM3->CNT);
+
+        	tmsstr[0] = 'Z';
+        	tmsstr[1] = slcan_nibble_to_ascii[(timestamp_us >> 28) & 0xF];
+        	tmsstr[2] = slcan_nibble_to_ascii[(timestamp_us >> 24) & 0xF];
+        	tmsstr[3] = slcan_nibble_to_ascii[(timestamp_us >> 20) & 0xF];
+        	tmsstr[4] = slcan_nibble_to_ascii[(timestamp_us >> 16) & 0xF];
+        	tmsstr[5] = slcan_nibble_to_ascii[(timestamp_us >> 12) & 0xF];
+        	tmsstr[6] = slcan_nibble_to_ascii[(timestamp_us >> 8) & 0xF];
+        	tmsstr[7] = slcan_nibble_to_ascii[(timestamp_us >> 4) & 0xF];
+        	tmsstr[8] = slcan_nibble_to_ascii[timestamp_us & 0xF];
+        	tmsstr[9] = '\r';
+            buf_comit_cdc_dest(10);
+        }
+        else
+        {
+            buf_enqueue_cdc(SLCAN_RET_ERR, SLCAN_RET_LEN);
+        }
+        return;
+    }
+
     // Set report mode
     if (can_get_bus_state() == BUS_CLOSED)
     {


### PR DESCRIPTION
close #13 