### PR TITLE
refactor: extract version string and TDC threshold into named constants

### DIFF
--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -42,6 +42,10 @@
 #define CAN_ROOT_CLOCK_MHZ              80
 #define CAN_BUS_LOAD_CYCLE_MS           100
 
+// Threshold for enabling Tx delay compensation
+// The offset value 0x28 corresponds to bitrate ~ 1Mbps @ 50% sampling point or ~ 2Mbps @ 100%.
+#define CAN_TDC_ENABLE_THRESHOLD        0x28
+
 // Public variable
 uint8_t can_dlc_to_bytes[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64};
 
@@ -141,10 +145,9 @@ HAL_StatusTypeDef can_enable(void)
         if (HAL_FDCAN_Init(&hfdcan1) != HAL_OK) return HAL_ERROR;
 
         // Setup Tx delay compensation
-        // The offset value 0x28 corresponds to bitrate ~ 1Mbps @ 50% sampling point or ~ 2Mbps @ 100%.
         // Turn off for <= 1Mbps and Turn on for >= 2Mbps
         uint32_t offset = can_bit_cfg_data.prescaler * can_bit_cfg_data.time_seg1;
-        if (offset <= 0x28)
+        if (offset <= CAN_TDC_ENABLE_THRESHOLD)
         {
             // Follow the recommended values in the link.
             // https://github.com/stm32-hotspot/CKB-STM32-FDCAN-8Mbs/blob/8a22560/NUCLEO-G0B1/Core/Src/main.c#L139-L141

--- a/usb2canfdv1-fw/App/Src/parser.c
+++ b/usb2canfdv1-fw/App/Src/parser.c
@@ -34,7 +34,8 @@
 #include "bootloader.h"
 #endif
 
-#define SLCAN_VERSION   "VW1K4"
+#define SLCAN_VERSION       "VW1K4"
+#define SLCAN_SW_VERSION    "2.1.0"
 #define SLCAN_RET_OK    ((uint8_t*)"\r")
 #define SLCAN_RET_ERR   ((uint8_t*)"\a")
 #define SLCAN_RET_LEN   (1)
@@ -45,7 +46,7 @@ static char *hw_sw_ver = SLCAN_VERSION "\r";
 #else
 static char *hw_sw_ver = SLCAN_VERSION "-DEBUG\r";
 #endif
-static char *hw_sw_ver_detail = "v: hardware=\"USB2CANFDV1\", software=\"" "2.1.0" "\", url=\"" "github.com/Nakakiyo092/usb2canfdv1" "\"\r";
+static char *hw_sw_ver_detail = "v: hardware=\"USB2CANFDV1\", software=\"" SLCAN_SW_VERSION "\", url=\"" "github.com/Nakakiyo092/usb2canfdv1" "\"\r";
 static char *can_info = "I3050\r";
 static char *can_info_detail = "i: protocol=\"ISO-CANFD\", clock_mhz=80, controller=\"STM32G0B1CB\"\r";
 


### PR DESCRIPTION
Add `SLCAN_SW_VERSION` define in `parser.c` (placed under `SLCAN_VERSION`) and use it in `hw_sw_ver_detail` to make version bumps less error-prone. Add `CAN_TDC_ENABLE_THRESHOLD` define in `can.c` to replace the magic constant `0x28`, making the Tx delay compensation threshold self-documenting.

Closes #87

Generated with [Claude Code](https://claude.ai/code)