### PR TITLE
fix(buffer): apply code review corrections from issue #88

### DIFF
--- a/usb2canfdv1-fw/App/Inc/buffer.h
+++ b/usb2canfdv1-fw/App/Inc/buffer.h
@@ -23,6 +23,7 @@
 #ifndef __BUFFER_H__
 #define __BUFFER_H__
 
+#include <stdint.h>
 #include "can.h"
 #include "usbd_cdc.h"
 

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -73,6 +73,8 @@ void buf_init(void)
     buf_can_tx.send = 0;
     buf_can_tx.tail = 0;
     buf_can_tx.full = 0;
+
+    slcan_str_index = 0;
 }
 
 // Process

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -347,7 +347,7 @@ HAL_StatusTypeDef buf_commit_can_head(void)
 // Delete one frame from the can tx buffer
 HAL_StatusTypeDef buf_release_can_tail(void)
 {
-    while ((buf_can_tx.head == buf_can_tx.tail) && !buf_can_tx.full)
+    if ((buf_can_tx.head == buf_can_tx.tail) && !buf_can_tx.full)
     {
         return HAL_ERROR;
     }

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -276,6 +276,7 @@ FDCAN_TxHeaderTypeDef *buf_get_can_sent_header(uint8_t marker)
         return NULL;
     }
 
+    // TODO Deduplicate marker-search logic shared with buf_get_can_sent_data (e.g., static buf_find_can_marker helper)
     uint8_t idx = buf_can_tx.tail;
     while (idx != buf_can_tx.send)
     {
@@ -312,6 +313,7 @@ uint8_t *buf_get_can_sent_data(uint8_t marker)
         return NULL;
     }
 
+    // TODO Deduplicate marker-search logic shared with buf_get_can_sent_header (e.g., static buf_find_can_marker helper)
     uint8_t idx = buf_can_tx.tail;
     while (idx != buf_can_tx.send)
     {

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -31,7 +31,7 @@
 // Maximum number of frames between tail and send index
 // In one main loop, max. 3 frames can be sent, 1 tx event can be processed.
 // The value below is set considering the case with 3 successful transmissions followed by 9 failed ones.
-#define BUF_MAX_NBR_SENT_FRAMES         (3 * 3 * 2)         // SRAMCAN_TFQ_NBR 3 * SRAMCAN_TEF_NBR 3 * Margin
+#define BUF_MAX_NBR_SENT_FRAMES         (3 * 3 * 2)         // SRAMCAN_TFQ_NBR 3 * SRAMCAN_TEF_NBR 3 * Margin (must be < BUF_CAN_TXQUEUE_LEN)
 
 // Cirbuf structure for CAN TX frames
 struct BufCanTx

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -259,7 +259,7 @@ FDCAN_TxHeaderTypeDef *buf_get_can_head_header(void)
 {
     if (buf_can_tx.full)
     {
-        slcan_raise_error(SLCAN_STS_CAN_TX_FIFO_FULL);;
+        slcan_raise_error(SLCAN_STS_CAN_TX_FIFO_FULL);
         return NULL;
     }
 
@@ -295,7 +295,7 @@ uint8_t *buf_get_can_head_data(void)
 {
     if (buf_can_tx.full)
     {
-        slcan_raise_error(SLCAN_STS_CAN_TX_FIFO_FULL);;
+        slcan_raise_error(SLCAN_STS_CAN_TX_FIFO_FULL);
         return NULL;
     }
 

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -55,8 +55,8 @@ static uint8_t slcan_str_index = 0;
 
 // Private prototypes
 static HAL_StatusTypeDef buf_release_can_tail(void);
-static void buf_disable_irq();
-static void buf_enable_irq();
+static void buf_disable_irq(void);
+static void buf_enable_irq(void);
 
 // Initializes
 void buf_init(void)
@@ -395,13 +395,13 @@ void buf_clear_can_buffer(void)
 }
 
 // Disable/Enable IRQ with memory barrier
-void buf_disable_irq()
+static void buf_disable_irq(void)
 {
     __disable_irq();
     __DSB(); // Data Synchronization Barrier
     __ISB(); // Instruction Synchronization Barrier
 }
-void buf_enable_irq()
+static void buf_enable_irq(void)
 {
     __enable_irq();
     __DSB();

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -191,7 +191,7 @@ void buf_process(void)
 
         // send is advanced unconditionally (drop-on-fail): advancing only on success risks
         // an infinite loop if the frame is permanently invalid (e.g., bad DLC). Frame loss
-        // is surfaced to the host via marker mismatch detected by the F command.
+        // is detected as a marker mismatch and surfaced to the host via the F command.
         buf_can_tx.send = (buf_can_tx.send + 1) % BUF_CAN_TXQUEUE_LEN;
 
         uint16_t nbr_sent_frames;   // Number of frames in HAL waiting for being sent

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -187,6 +187,9 @@ void buf_process(void)
                                                &buf_can_tx.header[buf_can_tx.send], 
                                                buf_can_tx.data[buf_can_tx.send]);
 
+        // send is advanced unconditionally (drop-on-fail): advancing only on success risks
+        // an infinite loop if the frame is permanently invalid (e.g., bad DLC). Frame loss
+        // is surfaced to the host via marker mismatch detected by the F command.
         buf_can_tx.send = (buf_can_tx.send + 1) % BUF_CAN_TXQUEUE_LEN;
 
         uint16_t nbr_sent_frames;   // Number of frames in HAL waiting for being sent


### PR DESCRIPTION
Applies all code review fixes from issue #88 (items not tracked in separate issues):

- while → if in buf_release_can_tail
- Document drop-on-fail rationale for unconditional send advance
- Reset slcan_str_index in buf_init
- Remove double semicolons in buf_get_can_head_header/data
- Add static and (void) to buf_disable/enable_irq
- Add #include <stdint.h> to buffer.h
- Add TODO for duplicated marker-search logic
- Note BUF_MAX_NBR_SENT_FRAMES constraint vs BUF_CAN_TXQUEUE_LEN

References: #88

Generated with [Claude Code](https://claude.ai/code)