### PR TITLE
fix(can): address code review findings from #89

### DIFF
--- a/usb2canfdv1-fw/App/Inc/can.h
+++ b/usb2canfdv1-fw/App/Inc/can.h
@@ -87,6 +87,7 @@ struct CanBitrateCfg
 #define CAN_MAX_DATALEN                 64  // CAN maximum data length. Must be 64 for canfd.
 
 // Public variable
+#define CAN_DLC_TO_BYTES_SIZE           16  // Number of entries in can_dlc_to_bytes (DLC 0x0..0xF)
 extern uint8_t can_dlc_to_bytes[];
 
 // Prototypes

--- a/usb2canfdv1-fw/App/Inc/can.h
+++ b/usb2canfdv1-fw/App/Inc/can.h
@@ -23,6 +23,8 @@
 #ifndef _CAN_H
 #define _CAN_H
 
+#include "stm32g0xx_hal.h"
+
 // Classic CAN / CANFD nominal bitrates
 enum CanBitrateNominal
 {

--- a/usb2canfdv1-fw/App/Inc/can.h
+++ b/usb2canfdv1-fw/App/Inc/can.h
@@ -99,7 +99,7 @@ HAL_StatusTypeDef can_set_nominal_bitrate(enum CanBitrateNominal bitrate);
 HAL_StatusTypeDef can_set_data_bitrate(enum CanBitrateData bitrate);
 HAL_StatusTypeDef can_set_nominal_bitrate_cfg(struct CanBitrateCfg bitrate_cfg);
 HAL_StatusTypeDef can_set_data_bitrate_cfg(struct CanBitrateCfg bitrate_cfg);
-struct CanBitrateCfg can_get_bitrate_cfg(void);
+struct CanBitrateCfg can_get_nominal_bitrate_cfg(void);
 struct CanBitrateCfg can_get_data_bitrate_cfg(void);
 
 // Filter functions

--- a/usb2canfdv1-fw/App/Inc/can.h
+++ b/usb2canfdv1-fw/App/Inc/can.h
@@ -47,6 +47,7 @@ enum CanBitrateData
     CAN_DATA_BITRATE_500K = 0,
     CAN_DATA_BITRATE_1M = 1,
     CAN_DATA_BITRATE_2M = 2,
+    // value 3 (3 Mbps) is intentionally absent: not supported by the STM32G0 FDCAN peripheral
     CAN_DATA_BITRATE_4M = 4,
     CAN_DATA_BITRATE_5M = 5,
 

--- a/usb2canfdv1-fw/App/Inc/can.h
+++ b/usb2canfdv1-fw/App/Inc/can.h
@@ -47,7 +47,7 @@ enum CanBitrateData
     CAN_DATA_BITRATE_500K = 0,
     CAN_DATA_BITRATE_1M = 1,
     CAN_DATA_BITRATE_2M = 2,
-    // value 3 (3 Mbps) is intentionally absent: not supported by the STM32G0 FDCAN peripheral
+    // value 3 (3 Mbps) is not supported: exactly 3 Mbps cannot be achieved with this clock setup
     CAN_DATA_BITRATE_4M = 4,
     CAN_DATA_BITRATE_5M = 5,
 

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -519,6 +519,7 @@ struct CanBitrateCfg can_get_nominal_bitrate_cfg(void)
 }
 
 // Set filter for standard CAN ID
+// Code and mask entries outside the valid range are left unchanged.
 HAL_StatusTypeDef can_set_filter_std(FunctionalState state, uint32_t code, uint32_t mask)
 {
     HAL_StatusTypeDef ret = HAL_OK;
@@ -545,6 +546,7 @@ HAL_StatusTypeDef can_set_filter_std(FunctionalState state, uint32_t code, uint3
 }
 
 // Set filter for extended CAN ID
+// Code and mask entries outside the valid range are left unchanged.
 HAL_StatusTypeDef can_set_filter_ext(FunctionalState state, uint32_t code, uint32_t mask)
 {
     HAL_StatusTypeDef ret = HAL_OK;
@@ -624,7 +626,11 @@ HAL_StatusTypeDef can_set_mode(uint32_t mode)
         // cannot set mode while on bus
         return HAL_ERROR;
     }
-    if (!IS_FDCAN_MODE(mode)) return HAL_ERROR;
+    if (!IS_FDCAN_MODE(mode))
+    {
+        // out of range (RESTRICTED can be accepted)
+        return HAL_ERROR;
+    }
     can_mode = mode;
 
     return HAL_OK;

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -118,6 +118,8 @@ HAL_StatusTypeDef can_enable(void)
         // Reset error counter etc.
         __HAL_RCC_FDCAN_FORCE_RESET();
         __HAL_RCC_FDCAN_RELEASE_RESET();
+        can_error_state = (struct CanErrorState){0};
+        can_error_state.last_err_code = FDCAN_PROTOCOL_ERROR_NONE;
 
         hfdcan1.Init.ClockDivider = FDCAN_CLOCK_DIV1;
         hfdcan1.Init.FrameFormat = FDCAN_FRAME_FD_BRS;
@@ -178,7 +180,6 @@ HAL_StatusTypeDef can_enable(void)
         can_update_bit_time_ns();
         can_clear_cycle_time();
         can_bus_load_ppm = 0;
-        can_error_state.last_err_code = FDCAN_PROTOCOL_ERROR_NONE;
 
         led_turn_txd(LED_OFF);
 
@@ -200,10 +201,10 @@ HAL_StatusTypeDef can_disable(void)
         // Reset error counter etc.
         __HAL_RCC_FDCAN_FORCE_RESET();
         __HAL_RCC_FDCAN_RELEASE_RESET();
+        can_error_state = (struct CanErrorState){0};
+        can_error_state.last_err_code = FDCAN_PROTOCOL_ERROR_NONE;
 
         buf_clear_can_buffer();
-
-        can_error_state = (struct CanErrorState){0};
 
         led_turn_txd(LED_ON);
 

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -520,14 +520,14 @@ struct CanBitrateCfg can_get_bitrate_cfg(void)
 HAL_StatusTypeDef can_set_filter_std(FunctionalState state, uint32_t code, uint32_t mask)
 {
     HAL_StatusTypeDef ret = HAL_OK;
-    
+
     if (can_bus_state == BUS_OPENED) return HAL_ERROR;
     if (state == ENABLE)
         can_std_filter.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
     else if (state == DISABLE)
         can_std_filter.FilterConfig = FDCAN_FILTER_DISABLE;
     else
-        ret = HAL_ERROR;
+        return HAL_ERROR;
 
     if (code > 0x7FF)
         ret = HAL_ERROR;
@@ -538,7 +538,7 @@ HAL_StatusTypeDef can_set_filter_std(FunctionalState state, uint32_t code, uint3
         ret = HAL_ERROR;
     else
         can_std_filter.FilterID2 = mask;
-    
+
     return ret;
 }
 
@@ -546,14 +546,14 @@ HAL_StatusTypeDef can_set_filter_std(FunctionalState state, uint32_t code, uint3
 HAL_StatusTypeDef can_set_filter_ext(FunctionalState state, uint32_t code, uint32_t mask)
 {
     HAL_StatusTypeDef ret = HAL_OK;
-    
+
     if (can_bus_state == BUS_OPENED) return HAL_ERROR;
     if (state == ENABLE)
         can_ext_filter.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
     else if (state == DISABLE)
         can_ext_filter.FilterConfig = FDCAN_FILTER_DISABLE;
     else
-        ret = HAL_ERROR;
+        return HAL_ERROR;
 
     if (code > 0x1FFFFFFF)
         ret = HAL_ERROR;
@@ -564,7 +564,7 @@ HAL_StatusTypeDef can_set_filter_ext(FunctionalState state, uint32_t code, uint3
         ret = HAL_ERROR;
     else
         can_ext_filter.FilterID2 = mask;
-    
+
     return ret;
 }
 

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -622,6 +622,7 @@ HAL_StatusTypeDef can_set_mode(uint32_t mode)
         // cannot set mode while on bus
         return HAL_ERROR;
     }
+    if (!IS_FDCAN_MODE(mode)) return HAL_ERROR;
     can_mode = mode;
 
     return HAL_OK;

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -511,7 +511,7 @@ struct CanBitrateCfg can_get_data_bitrate_cfg(void)
 }
 
 // Get the nominal bitrate configuration of the CAN peripheral
-struct CanBitrateCfg can_get_bitrate_cfg(void)
+struct CanBitrateCfg can_get_nominal_bitrate_cfg(void)
 {
     return can_bit_cfg_nominal;
 }

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -203,6 +203,8 @@ HAL_StatusTypeDef can_disable(void)
 
         buf_clear_can_buffer();
 
+        can_error_state = (struct CanErrorState){0};
+
         led_turn_txd(LED_ON);
 
         can_bus_state = BUS_CLOSED;

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -69,7 +69,7 @@ static uint32_t can_bus_load_ppm = 0;           // Current bus load in ppm
 // Private methods
 static void can_update_bit_time_ns(void);
 static uint16_t can_get_bit_number_in_rx_frame(FDCAN_RxHeaderTypeDef *pRxHeader);
-static uint16_t can_get_bit_number_in_tx_event(FDCAN_TxEventFifoTypeDef *pRxHeader);
+static uint16_t can_get_bit_number_in_tx_event(FDCAN_TxEventFifoTypeDef *pTxEvent);
 
 // Initialize CAN peripheral settings, but don't actually start the peripheral
 void can_init(void)

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -702,7 +702,7 @@ FDCAN_HandleTypeDef *can_get_handle(void)
 }
 
 // Get the nominal one bit time in nanoseconds
-void can_update_bit_time_ns(void)
+static void can_update_bit_time_ns(void)
 {
     // Number of time quanta (Tq) in one bit
     can_bit_time_ns = ((uint32_t)1 + can_bit_cfg_nominal.time_seg1 + can_bit_cfg_nominal.time_seg2);
@@ -715,7 +715,7 @@ void can_update_bit_time_ns(void)
 }
 
 // Return the duration of the rx frame in the nominal bit number
-uint16_t can_get_bit_number_in_rx_frame(FDCAN_RxHeaderTypeDef *pRxHeader)
+static uint16_t can_get_bit_number_in_rx_frame(FDCAN_RxHeaderTypeDef *pRxHeader)
 {
     uint16_t time_msg, time_data;
     uint8_t data_bytes = can_dlc_to_bytes[CAN_HAL_DLC_TO_STD_DLC(pRxHeader->DataLength)];
@@ -774,7 +774,7 @@ uint16_t can_get_bit_number_in_rx_frame(FDCAN_RxHeaderTypeDef *pRxHeader)
 }
 
 // Return the duration of the tx event in the nominal bit number
-uint16_t can_get_bit_number_in_tx_event(FDCAN_TxEventFifoTypeDef *pTxEvent)
+static uint16_t can_get_bit_number_in_tx_event(FDCAN_TxEventFifoTypeDef *pTxEvent)
 {
     FDCAN_RxHeaderTypeDef frame_header;
     //frame_header.Identifier = pTxEvent->Identifier;

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -658,7 +658,7 @@ FunctionalState can_is_tx_enabled(void)
 {
     if (can_bus_state == BUS_CLOSED)
         return DISABLE;
-    else if (hfdcan1.Init.Mode == FDCAN_MODE_BUS_MONITORING)
+    else if (can_mode == FDCAN_MODE_BUS_MONITORING)
         return DISABLE;
     else if (can_error_state.bus_off)
         return DISABLE;

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -208,11 +208,11 @@ HAL_StatusTypeDef nvm_update_startup_cfg(uint8_t mode)
     // Make raw data for nominal bitrate
     uint64_t nom_bitrate = 0;
 
-    if (0xFF < can_get_bitrate_cfg().prescaler) return HAL_ERROR;
-    nom_bitrate = (nom_bitrate | (uint64_t)can_get_bitrate_cfg().prescaler);
-    nom_bitrate = (nom_bitrate | ((uint64_t)can_get_bitrate_cfg().time_seg1 << 8));
-    nom_bitrate = (nom_bitrate | ((uint64_t)can_get_bitrate_cfg().time_seg2 << 16));
-    nom_bitrate = (nom_bitrate | ((uint64_t)can_get_bitrate_cfg().sjw << 24));
+    if (0xFF < can_get_nominal_bitrate_cfg().prescaler) return HAL_ERROR;
+    nom_bitrate = (nom_bitrate | (uint64_t)can_get_nominal_bitrate_cfg().prescaler);
+    nom_bitrate = (nom_bitrate | ((uint64_t)can_get_nominal_bitrate_cfg().time_seg1 << 8));
+    nom_bitrate = (nom_bitrate | ((uint64_t)can_get_nominal_bitrate_cfg().time_seg2 << 16));
+    nom_bitrate = (nom_bitrate | ((uint64_t)can_get_nominal_bitrate_cfg().sjw << 24));
     nom_bitrate = NVM_WRITE_MEM_STS(nom_bitrate);
 
     // Make raw data for data bitrate


### PR DESCRIPTION
Fixes from the code review in issue #89, each as a separate commit:

- Add missing `static` to three internal function definitions
- Return early on invalid `state` in filter set functions
- Validate `mode` parameter in `can_set_mode` using `IS_FDCAN_MODE`
- Fix copy-paste parameter name `pRxHeader` → `pTxEvent` in forward declaration
- Make `can.h` self-contained by adding HAL include
- Rename `can_get_bitrate_cfg` → `can_get_nominal_bitrate_cfg` (symmetric with setter)
- Document missing value 3 in `CanBitrateData` enum
- Add `CAN_DLC_TO_BYTES_SIZE` constant for bounds-checking
- Use `can_mode` instead of `hfdcan1.Init.Mode` in `can_is_tx_enabled`
- Reset `can_error_state` on `can_disable`

Generated with [Claude Code](https://claude.ai/code)