### PR TITLE
fix: led.c and led.h code review fixes

### DIFF
--- a/usb2canfdv1-fw/App/Inc/led.h
+++ b/usb2canfdv1-fw/App/Inc/led.h
@@ -25,11 +25,11 @@
 
 #include "main.h"
 
-// LED state
+// LED state (active-low: LED_ON = GPIO_PIN_RESET drives pin LOW to light the LED)
 enum LedState
 {
-    LED_ON,
-    LED_OFF
+    LED_ON  = GPIO_PIN_RESET,
+    LED_OFF = GPIO_PIN_SET
 };
 
 // GPIO definitions

--- a/usb2canfdv1-fw/App/Inc/led.h
+++ b/usb2canfdv1-fw/App/Inc/led.h
@@ -38,7 +38,7 @@ enum LedState
 
 // Prototypes
 void led_init(void);
-void led_turn_txd(enum LedState state);
+void led_turn_txd(enum LedState state); // No led_turn_rxd: RX LED is managed exclusively via led_blink_rxd/led_process
 void led_blink_sequence(uint8_t numblinks);
 void led_blink_txd(void);
 void led_blink_rxd(void);

--- a/usb2canfdv1-fw/App/Inc/led.h
+++ b/usb2canfdv1-fw/App/Inc/led.h
@@ -37,7 +37,7 @@ enum LedState
 #define LED_TXD LED_TXD_GPIO_Port , LED_TXD_Pin
 
 // Prototypes
-void led_init();
+void led_init(void);
 void led_turn_txd(enum LedState state);
 void led_blink_sequence(uint8_t numblinks);
 void led_blink_txd(void);

--- a/usb2canfdv1-fw/App/Src/led.c
+++ b/usb2canfdv1-fw/App/Src/led.c
@@ -98,6 +98,8 @@ void led_process(void)
     {
         HAL_GPIO_WritePin(LED_RXD, LED_ON);
         HAL_GPIO_WritePin(LED_TXD, LED_ON);
+        led_rxd_last_state = LED_OFF;
+        led_txd_last_state = LED_OFF;
         led_error_was_indicating = 1;
     }
     // Otherwise, normal LED operation

--- a/usb2canfdv1-fw/App/Src/led.c
+++ b/usb2canfdv1-fw/App/Src/led.c
@@ -122,7 +122,6 @@ void led_process(void)
         // If LED has been on for long enough, turn it off
         if (led_txd_last_state == LED_ON && (uint32_t)(HAL_GetTick() - led_txd_last_time) > LED_BLINK_DURATION)
         {
-            // Invert LED
             HAL_GPIO_WritePin(LED_TXD, LED_OFF);
             led_txd_last_time = HAL_GetTick();
             led_txd_last_state = LED_OFF;

--- a/usb2canfdv1-fw/App/Src/led.c
+++ b/usb2canfdv1-fw/App/Src/led.c
@@ -37,7 +37,7 @@ static enum LedState led_txd_last_state = LED_OFF;
 static uint8_t led_error_was_indicating = 0;
 
 // Initialize LED GPIOs
-void led_init()
+void led_init(void)
 {
     HAL_GPIO_WritePin(LED_RXD, LED_ON);
     HAL_GPIO_WritePin(LED_TXD, LED_ON);


### PR DESCRIPTION
Applies five fixes identified in code review (issue #91), each as a separate commit:

- Remove stale "Invert LED" comment (led.c:125)
- Pin LedState enum values to GPIO_PinState HAL constants (Option A)
- Use (void) parameter list in led_init declaration and definition
- Reset led_*_last_state when entering error indication block
- Document intentional absence of led_turn_rxd in led.h

Closes #91

Generated with [Claude Code](https://claude.ai/code)