### PR TITLE
fix: nvm.c code review fixes (items 1,2,5,6,7 and design comments)

### DIFF
--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -44,6 +44,8 @@ enum NvmMemoryStatus
 #define NVM_ADDR_STP_FILTER_CODE  (NVM_ADDR_ORIGIN + 0x020UL)
 #define NVM_ADDR_STP_FILTER_MASK  (NVM_ADDR_ORIGIN + 0x028UL)
 
+// Note: Integrity check relies solely on a 4-bit status nibble. A single bit-flip
+// in the payload will silently pass NVM_IS_WRITTEN. No CRC or checksum is implemented.
 #define NVM_EXTRACT_MEM_STS(val)  ((uint8_t)(((val) >> 60) & 0x0F))
 #define NVM_IS_WRITTEN(val)       (NVM_EXTRACT_MEM_STS(val) == NVM_MEMORY_WRITTEN)
 #define NVM_WRITE_MEM_STS(val)    ((((uint64_t)val) & 0x0FFFFFFFFFFFFFFF) | (((uint64_t)NVM_MEMORY_WRITTEN) << 60))

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -70,8 +70,6 @@ void nvm_init(void)
     nvm_stp_data_bitrate_raw =  *(uint64_t *)NVM_ADDR_STP_DATA_BITRATE;
     nvm_stp_filter_code_raw =   *(uint64_t *)NVM_ADDR_STP_FILTER_CODE;
     nvm_stp_filter_mask_raw =   *(uint64_t *)NVM_ADDR_STP_FILTER_MASK;
-
-    return;
 }
 
 // Get serial number

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -106,6 +106,9 @@ HAL_StatusTypeDef nvm_update_serial_number(uint16_t num)
 }
 
 // Apply auto startup configuration
+// Note: No rollback on partial failure — if a later step returns HAL_ERROR,
+// earlier settings may already be applied to live modules. Callers should treat
+// HAL_ERROR as an indication that the system state is partially configured.
 HAL_StatusTypeDef nvm_apply_startup_cfg(void)
 {
     // Check if the memory is written

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -266,8 +266,7 @@ HAL_StatusTypeDef nvm_write_to_flash(void)
     erase.NbPages = 1;
 
     uint32_t error = 0;
-    HAL_FLASHEx_Erase(&erase, &error);
-    if (error != NVM_ERASE_OK)
+    if (HAL_FLASHEx_Erase(&erase, &error) != HAL_OK || error != NVM_ERASE_OK)
     {
         HAL_FLASH_Lock();
         return HAL_ERROR;

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -140,6 +140,7 @@ HAL_StatusTypeDef nvm_apply_startup_cfg(void)
     slcan_set_report_mode(report_reg);
 
     // Read and apply bitrate
+    // Prescaler is stored in 8 bits; project decision limits it to 255 or less
     struct CanBitrateCfg bitrate;
     bitrate.prescaler = (uint16_t)((nvm_stp_nom_bitrate_raw) & 0xFF);
     bitrate.time_seg1 = (uint8_t)((nvm_stp_nom_bitrate_raw >> 8) & 0xFF);
@@ -205,6 +206,7 @@ HAL_StatusTypeDef nvm_update_startup_cfg(uint8_t mode)
     startup_cfg = NVM_WRITE_MEM_STS(startup_cfg);
 
     // Make raw data for nominal bitrate
+    // Prescaler is stored in 8 bits; project decision limits it to 255 or less
     uint64_t nom_bitrate = 0;
 
     if (0xFF < can_get_bitrate_cfg().prescaler) return HAL_ERROR;
@@ -215,6 +217,7 @@ HAL_StatusTypeDef nvm_update_startup_cfg(uint8_t mode)
     nom_bitrate = NVM_WRITE_MEM_STS(nom_bitrate);
 
     // Make raw data for data bitrate
+    // Prescaler is stored in 8 bits; project decision limits it to 255 or less
     uint64_t data_bitrate = 0;
 
     if (0xFF < can_get_data_bitrate_cfg().prescaler) return HAL_ERROR;

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -92,9 +92,11 @@ HAL_StatusTypeDef nvm_update_serial_number(uint16_t num)
     }
 
     // Write to the flash
+    uint64_t prev_serial_number_raw = nvm_serial_number_raw;
     nvm_serial_number_raw = NVM_WRITE_MEM_STS(num);
     if (nvm_write_to_flash() != HAL_OK)
     {
+        nvm_serial_number_raw = prev_serial_number_raw;
         return HAL_ERROR;
     }
 
@@ -237,7 +239,12 @@ HAL_StatusTypeDef nvm_update_startup_cfg(uint8_t mode)
                 return HAL_OK;
 
     // Update the RAM data
-    nvm_stp_config_raw = startup_cfg;
+    uint64_t prev_stp_config_raw =      nvm_stp_config_raw;
+    uint64_t prev_stp_nom_bitrate_raw = nvm_stp_nom_bitrate_raw;
+    uint64_t prev_stp_data_bitrate_raw = nvm_stp_data_bitrate_raw;
+    uint64_t prev_stp_filter_code_raw = nvm_stp_filter_code_raw;
+    uint64_t prev_stp_filter_mask_raw = nvm_stp_filter_mask_raw;
+    nvm_stp_config_raw =      startup_cfg;
     nvm_stp_nom_bitrate_raw = nom_bitrate;
     nvm_stp_data_bitrate_raw = data_bitrate;
     nvm_stp_filter_code_raw = filter_code;
@@ -246,6 +253,11 @@ HAL_StatusTypeDef nvm_update_startup_cfg(uint8_t mode)
     // Write to the flash
     if (nvm_write_to_flash() != HAL_OK)
     {
+        nvm_stp_config_raw =      prev_stp_config_raw;
+        nvm_stp_nom_bitrate_raw = prev_stp_nom_bitrate_raw;
+        nvm_stp_data_bitrate_raw = prev_stp_data_bitrate_raw;
+        nvm_stp_filter_code_raw = prev_stp_filter_code_raw;
+        nvm_stp_filter_mask_raw = prev_stp_filter_mask_raw;
         return HAL_ERROR;
     }
     

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -24,7 +24,6 @@
 
 #include "stm32g0xx_hal.h"
 #include "can.h"
-#include "led.h"
 #include "nvm.h"
 #include "slcan.h"
 

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -270,6 +270,9 @@ HAL_StatusTypeDef nvm_update_startup_cfg(uint8_t mode)
 }
 
 // Write the RAM data to the data area in the flash memory
+// Note: No wear leveling — every write erases and rewrites the entire page,
+// consuming one flash erase cycle (~10,000–100,000 cycles rated). Acceptable
+// because config writes are infrequent in normal operation.
 HAL_StatusTypeDef nvm_write_to_flash(void)
 {
     // Unlock the flash


### PR DESCRIPTION
Fixes raised in code review #issue-92, with each item as a separate commit:

- Remove redundant `return;` at end of `nvm_init`
- Remove unused `#include "led.h"`
- Check return value of `HAL_FLASHEx_Erase`
- Revert RAM variables when flash write fails (both `nvm_update_serial_number` and `nvm_update_startup_cfg`)
- Document prescaler ≤ 255 constraint (project decision)
- Add comment about lack of data integrity check
- Add comment about wear leveling assumption
- Add comment about partial-success risk in `nvm_apply_startup_cfg`

Closes #92

Generated with [Claude Code](https://claude.ai/code)