### PR TITLE
doc: fix documentation issues identified in AI review

### DIFF
--- a/doc/1.-Introduction.md
+++ b/doc/1.-Introduction.md
@@ -20,7 +20,7 @@ it serves as one of such products that offers a casual way to connect to a singl
 
 ## Core values
 
-1. Conpatibility with the LAWICEL CAN ASCII protocol
+1. Compatibility with the LAWICEL CAN ASCII protocol
 2. Simplicity - a human‑readable, less host coding, text‑based protocol
 3. Reliability
 4. Performance
@@ -34,7 +34,7 @@ Although backward compatibility was prioritized, the following aspects were inte
 
 This project does not support polling via commands.
 Incoming frames are reported to the host on a push basis.
-For this reason, the `P`, `A`, and `X` commands have been removed, which are already dectated as outdated by LAWICEL.
+For this reason, the `P`, `A`, and `X` commands have been removed, which are already deprecated as outdated by LAWICEL.
 
 ### Disable automatic bus off recovery
 
@@ -62,7 +62,7 @@ Always start each session by sending a `[CR]` to clear any previous command or q
 (since false or leftover characters may be present in the queue after power‑up or from a previous session).
 Then press `V` and hit enter and the device will reply `Vhhss`, where `hh` is the hardware version and `ss` is the software version.
 
-It is reccomended to close the CAN port with `C` before setting the CAN speed, because the current port status is unknown.
+It is recommended to close the CAN port with `C` before setting the CAN speed, because the current port status is unknown.
 
 Next, set up the CAN nominal speed with the `S` or `s` command, and the CAN data speed with the `Y` or `y` command.
 It is recommended to configure all available settings to your preferred values, as some old configuration values may still remain.
@@ -70,7 +70,7 @@ These include settings for nominal bit-rates (`S` or `s`), data bit-rates (`Y` o
 
 Then open the CAN port with `O`.
 The device will now operate for both sending and receiving CAN frames.
-The RX and TX LEDs indicate when a CAN frame has been succesfully sent or received by the device.
+The RX and TX LEDs indicate when a CAN frame has been successfully sent or received by the device.
 
 Send frames using the `t` or `T` command (`b`, `B`, `d` or `D`, if you prefer CAN FD frames), 
 and wait for the response to confirm whether it was placed in the CAN FIFO transmission queue.

--- a/doc/2.-Command-List.md
+++ b/doc/2.-Command-List.md
@@ -1,68 +1,68 @@
 # Summary table
 
 ```
----------------------------------------------------------------------------------------------------------
-CMD | STATE | SYNTAX                | DESCRIPTION                                                   | ON
----------------------------------------------------------------------------------------------------------
-'S' |  YES  |  Sn[CR]               | Sets up with CAN FD nominal bit rate where n is 0-8.          |  A
+----------------------------------------------------------------------------------------------------------
+CMD | STATE | SYNTAX                | DESCRIPTION                                                   | FROM
+----------------------------------------------------------------------------------------------------------
+'S' |  YES  |  Sn[CR]               | Sets up with CAN FD nominal bit rate where n is 0-8.          |    A
     |       |                       | S0 10kbps          S3 100kbps         S6 500kbps              |
     |       |                       | S1 20kbps          S4 125kbps         S7 800kbps              |
     |       |                       | S2 50kbps          S5 250kbps         S8 1Mbps                |
-'s' |  TODO |  sxxyy[CR]            | Sets up CAN nominal bit rate and bit timing,                  |  A
+'s' |  TODO |  sxxyy[CR]            | Sets up CAN nominal bit rate and bit timing,                  |    A
     |       |                       | where xx and yy are hex values.                               |
-    |  YES  |  sddxxyyzz[CR]        | Sets up CAN FD nominal bit rate and bit timing,               | DY
+    |  YES  |  sddxxyyzz[CR]        | Sets up CAN FD nominal bit rate and bit timing,               |   DY
     |       |                       | where dd, xx, yy and zz are hex values.                       |
-'Y' |  YES  |  Yn[CR]               | Sets up with CAN FD data bit rate where n is 0-2, 4, 5.       | CY
+'Y' |  YES  |  Yn[CR]               | Sets up with CAN FD data bit rate where n is 0-2, 4, 5.       |   CY
     |       |                       | Y0 500kbps         Y3 3Mbps (N/A)                             |
     |       |                       | Y1 1Mbps           Y4 4Mbps                                   |
     |       |                       | Y2 2Mbps           Y5 5Mbps                                   |
-'y' |  YES  |  yddxxyyzz[CR]        | Sets up CAN FD data bit rate and bit timing,                  | DY
+'y' |  YES  |  yddxxyyzz[CR]        | Sets up CAN FD data bit rate and bit timing,                  |   DY
     |       |                       | where dd, xx, yy and zz are hex values.                       |
-'O' |  YES  |  O[CR]                | Opens the CAN FD channel in normal mode.                      |  A
+'O' |  YES  |  O[CR]                | Opens the CAN FD channel in normal mode.                      |    A
     |       |                       | Both sending & receiving are enabled.                         |
-'L' |  YES  |  L[CR]                | Opens the CAN FD channel in listen only mode.                 |  A
+'L' |  YES  |  L[CR]                | Opens the CAN FD channel in listen only mode.                 |    A
     |       |                       | Only receiving is enabled.                                    |
-'C' |  YES  |  C[CR]                | Closes the CAN FD channel.                                    |  A
-'r' |  YES  |  riiil[CR]            | Transmits a base remote frame.                                |  A
-'R' |  YES  |  Riiiiiiiil[CR]       | Transmits an extended remote frame.                           |  A
-'t' |  YES  |  tiiildd...[CR]       | Transmits a classical base data frame.                        |  A
-'T' |  YES  |  Tiiiiiiiildd...[CR]  | Transmits a classical extended data frame.                    |  A
-'d' |  YES  |  diiildd...[CR]       | Transmits a FD base data frame without bit rate switch.       |  B
-'D' |  YES  |  Diiiiiiiildd...[CR]  | Transmits a FD extended data frame without bit rate switch.   |  B
-'b' |  YES  |  biiildd...[CR]       | Transmits a FD base data frame with bit rate switch.          |  B
-'B' |  YES  |  Biiiiiiiildd...[CR]  | Transmits a FD extended data frame with bit rate switch.      |  B
-'P' |   -   |  P[CR]                | Polls incoming FIFO for CAN frames (single poll).             |  A
-'A' |   -   |  A[CR]                | Polls incoming FIFO for CAN frames (all pending frames).      |  A
-'F' |  YES  |  F[CR]                | Reads status flags.                                           |  A
-'f' |  YES  |  f[CR]                | Reads detailed status.                                        |  Y
-'X' |   -   |  Xn[CR]               | Sets Auto Poll/Send ON/OFF for received frames.               |  A
-'W' |  YES  |  Wn[CR]               | Sets up filter mode setting.                                  | AY
+'C' |  YES  |  C[CR]                | Closes the CAN FD channel.                                    |    A
+'r' |  YES  |  riiil[CR]            | Transmits a base remote frame.                                |    A
+'R' |  YES  |  Riiiiiiiil[CR]       | Transmits an extended remote frame.                           |    A
+'t' |  YES  |  tiiildd...[CR]       | Transmits a classical base data frame.                        |    A
+'T' |  YES  |  Tiiiiiiiildd...[CR]  | Transmits a classical extended data frame.                    |    A
+'d' |  YES  |  diiildd...[CR]       | Transmits a FD base data frame without bit rate switch.       |    B
+'D' |  YES  |  Diiiiiiiildd...[CR]  | Transmits a FD extended data frame without bit rate switch.   |    B
+'b' |  YES  |  biiildd...[CR]       | Transmits a FD base data frame with bit rate switch.          |    B
+'B' |  YES  |  Biiiiiiiildd...[CR]  | Transmits a FD extended data frame with bit rate switch.      |    B
+'P' |   -   |  P[CR]                | Polls incoming FIFO for CAN frames (single poll).             |    A
+'A' |   -   |  A[CR]                | Polls incoming FIFO for CAN frames (all pending frames).      |    A
+'F' |  YES  |  F[CR]                | Reads status flags.                                           |    A
+'f' |  YES  |  f[CR]                | Reads detailed status.                                        |    Y
+'X' |   -   |  Xn[CR]               | Sets Auto Poll/Send ON/OFF for received frames.               |    A
+'W' |  YES  |  Wn[CR]               | Sets up filter mode setting.                                  |   AY
     |       |                       | W0 Dual filter mode (TODO)                                    |
     |       |                       | W1 Single filter mode (N/A)                                   |
-    |       |                       | W2 Simple filter mode                                         |   
-'M' |  YES  |  Mxxxxxxxx[CR]        | Sets Acceptance Code Register (ACn Register).                 |  A
-'m' |  YES  |  mxxxxxxxx[CR]        | Sets Acceptance Mask Register (AMn Register).                 |  A
-'U' |   -   |  Un[CR]               | Sets up UART with a new baud rate where n is 0-6.             |  A
-'V' |  YES  |  V[CR]                | Gets software and hardware version characters.                |  A
-'v' |  YES  |  v[CR]                | Gets detailed version information.                            | CY
-'I' |  YES  |  I[CR]                | Gets CAN FD controller information.                           | EY
-'i' |  YES  |  i[CR]                | Gets detailed CAN FD controller information.                  | EY
-'N' |  YES  |  N[CR]                | Gets serial number of the hardware.                           |  A
-    |       |  Nxxxx[CR]            | Sets serial number of the hardware to xxxx,                   |  Y
+    |       |                       | W2 Simple filter mode                                         |
+'M' |  YES  |  Mxxxxxxxx[CR]        | Sets Acceptance Code Register (ACn Register).                 |    A
+'m' |  YES  |  mxxxxxxxx[CR]        | Sets Acceptance Mask Register (AMn Register).                 |    A
+'U' |   -   |  Un[CR]               | Sets up UART with a new baud rate where n is 0-6.             |    A
+'V' |  YES  |  V[CR]                | Gets software and hardware version characters.                |    A
+'v' |  YES  |  v[CR]                | Gets detailed version information.                            |   CY
+'I' |  YES  |  I[CR]                | Gets CAN FD controller information.                           |   EY
+'i' |  YES  |  i[CR]                | Gets detailed CAN FD controller information.                  |   EY
+'N' |  YES  |  N[CR]                | Gets serial number of the hardware.                           |    A
+    |       |  Nxxxx[CR]            | Sets serial number of the hardware to xxxx,                   |    Y
     |       |                       | where the new serial number xxxx is a hex value.              |
-'Z' |  YES  |  Zn[CR]               | Sets timestamp ON/OFF for received frames only.               | AY
+'Z' |  YES  |  Zn[CR]               | Sets timestamp ON/OFF for received frames only.               |   AY
     |       |                       | Z0 No timestamp                                               |
     |       |                       | Z1 Millisecond timestamp                                      |
-    |       |                       | Z2 Microsecond timestamp                                      |   
-    |       |  Z[CR]                | Gets current timestamp                                        |  Z
-'z' |  YES  |  znxyy[CR]            | Sets the reporting mechanism,                                 |  Y
+    |       |                       | Z2 Microsecond timestamp                                      |
+    |       |  Z[CR]                | Gets current timestamp                                        |    Z
+'z' |  YES  |  znxyy[CR]            | Sets the reporting mechanism,                                 |    Y
     |       |                       | where x and yy are hex values.                                |
-    |       |  z[CR]                | Gets detailed time.                                           |  Z
-'Q' |  YES  |  Qn[CR]               | Sets auto startup feature ON/OFF (from power on).             |  A
+    |       |  z[CR]                | Gets detailed time.                                           |    Z
+'Q' |  YES  |  Qn[CR]               | Sets auto startup feature ON/OFF (from power on).             |    A
     |       |                       | Q0 Auto startup off                                           |
     |       |                       | Q1 Auto startup in normal mode                                |
     |       |                       | Q2 Auto startup in listen only mode                           |
----------------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------------------
 ```
 
 The `STATE` of each command in this project is:
@@ -71,7 +71,7 @@ The `STATE` of each command in this project is:
 - `-`  : not supported and not planned
 
 
-Each command originated from the following sources (`ON`):
+Each command originated `FROM` the following sources:
 
 - `A` : [LAWICEL AB](https://www.canusb.com/) for a command to communicate with their products.
 - `B` : [Hadou-CAN](https://github.com/suburbanmarine/hadoucan-fw) project.

--- a/doc/2.-Command-List.md
+++ b/doc/2.-Command-List.md
@@ -71,7 +71,7 @@ The `STATE` of each command in this project is:
 - `-`  : not supported and not planned
 
 
-Each command is blamed `ON`:
+Each command originated from the following sources (`ON`):
 
 - `A` : [LAWICEL AB](https://www.canusb.com/) for a command to communicate with their products.
 - `B` : [Hadou-CAN](https://github.com/suburbanmarine/hadoucan-fw) project.
@@ -85,7 +85,7 @@ Each command is blamed `ON`:
 
 # General rules
 
-All command to the device must be terminated with CR and they are CASE sensitive.
+All commands to the device must be terminated with CR and they are CASE sensitive.
 
 All response from the device is terminated with CR except BELL for ERROR.
 The hexadecimal (hex) values are expressed with capital letters.
@@ -182,7 +182,7 @@ Example:
 
 Sets up CAN FD data bit rate to 2Mbps.
 
-Return:
+Returns:
 - CR for OK or BELL for ERROR.
 
 Note:
@@ -323,7 +323,7 @@ Precondition:
 Example:
 - `t10020011[CR]`
 
-Sends a classical CAN data frame with ID = 0x100 and 2 data bytes with the valued 0x00 and 0x11.
+Sends a classical CAN data frame with ID = 0x100 and 2 data bytes with the values 0x00 and 0x11.
 
 Returns:
 - `z[CR]` (if tx event disabled) or `[CR]` (if enabled) for OK or BELL for ERROR.
@@ -432,14 +432,14 @@ Returns:
 - `Fxx[CR]` for OK or BELL for ERROR,
 where `xx` is a hex value with 8 status bits:
 
-0. Sets when data is discarded to prevent CAN Tx or CDC Rx buffer overflow.  
-1. Sets when data is discarded to prevent CAN Rx or CDC Tx buffer overflow.  
-2. Sets when a CAN error counter reaches warning level (96 or more).  
-3. Sets when a CAN frame is lost in the driver side.  
-4. Sets when a CAN error counter reaches bus off level (256 or more).  
-5. Sets when a CAN error counter reaches error passive level (128 or more).  
-6. Arbitration lost (not supported)  
-7. Sets when a CAN error counter increments.  
+- bit 0: Sets when data is discarded to prevent CAN Tx or CDC Rx buffer overflow.
+- bit 1: Sets when data is discarded to prevent CAN Rx or CDC Tx buffer overflow.
+- bit 2: Sets when a CAN error counter reaches warning level (96 or more).
+- bit 3: Sets when a CAN frame is lost in the driver side.
+- bit 4: Sets when a CAN error counter reaches bus off level (256 or more).
+- bit 5: Sets when a CAN error counter reaches error passive level (128 or more).
+- bit 6: Arbitration lost (not supported)
+- bit 7: Sets when a CAN error counter increments.
 
 All flags are cleared after responding to the `F` command.
 They are also reset when the channel gets open by `O` command.
@@ -469,6 +469,9 @@ Reads detailed status.
 Returns:
 - `f<Something>[CR]` style information for OK or BELL for ERROR.
 
+Note:
+- The response is self-documented and human-readable. The exact format is intentionally left unspecified and may change in future firmware versions.
+
 
 ## Wn[CR]
 
@@ -489,6 +492,9 @@ Sets filter mode to dual filter mode (default).
 
 Returns:
 - CR for OK or BELL for ERROR.
+
+Note:
+- W0 (dual filter mode) is not yet implemented; the filter currently passes all frames in this mode.
 
 
 ## Mxxxxxxxx[CR]
@@ -580,6 +586,7 @@ Returns:
 - `v<Something>[CR]` style information for OK or BELL for ERROR.
 
 Note:
+- The response is self-documented and human-readable. The exact format is intentionally left unspecified and may change in future firmware versions.
 - The detailed version information includes a URL to a website hosting this firmware's source code.
 
 
@@ -619,6 +626,9 @@ Gets detailed CAN controller information.
 Returns:
 - `i<Something>[CR]` style information for OK or BELL for ERROR.
 
+Note:
+- The response is self-documented and human-readable. The exact format is intentionally left unspecified and may change in future firmware versions.
+
 
 ## N[CR]
 
@@ -639,7 +649,7 @@ Returns:
 ## Nxxxx[CR]
 
 Sets serial number of the device.
-Digits 1-9 and letters A-F can be used for serial number.
+Digits 0-9 and letters A-F can be used for serial number.
 
 - `xxxx`    The serial number in hex (0000 - FFFF)
 
@@ -709,14 +719,14 @@ Sets up the reporting mechanism.
 - `x`   Reserved
 - `yy`  A hex value with 8 bits:
 
-0. Enables (1) or disables (0) Rx frame report.
-1. Enables (1) or disables (0) Tx event report.
-2. Reserved
-3. Reserved
-4. Enables (1) or disables (0) ESI (Error Status Indicator) in Rx frame and Tx event report.
-5. Reserved
-6. Reserved
-7. Reserved
+- bit 0: Enables (1) or disables (0) Rx frame report.
+- bit 1: Enables (1) or disables (0) Tx event report.
+- bit 2: Reserved
+- bit 3: Reserved
+- bit 4: Enables (1) or disables (0) ESI (Error Status Indicator) in Rx frame and Tx event report.
+- bit 5: Reserved
+- bit 6: Reserved
+- bit 7: Reserved
 
 Precondition:
 - The CAN FD channel should be closed.
@@ -755,6 +765,9 @@ Gets detailed time at the moment the command is accepted.
 
 Returns:
 - `z<Something>[CR]` style information for OK or BELL for ERROR.
+
+Note:
+- The response is self-documented and human-readable. The exact format is intentionally left unspecified and may change in future firmware versions.
 
 
 ## Q[CR]

--- a/doc/3.-Acceptance-Filter.md
+++ b/doc/3.-Acceptance-Filter.md
@@ -14,7 +14,7 @@ This mode is not supported by this firmware.
 ### Mechanism
 
 The received frames are filtered based solely on their identifier extension bit (IDE) and CAN ID.
-For filtering, the inversed IDE value (~IDE), conbined with the CAN ID, 
+For filtering, the inversed IDE value (~IDE), combined with the CAN ID, 
 is compared against the corresponding bits of the Code and Mask as shown below.
 
 Mapping for a base CAN ID (11-bits)

--- a/doc/4.-Reporting-Mechanism.md
+++ b/doc/4.-Reporting-Mechanism.md
@@ -82,7 +82,7 @@ Denotes a successful transmission of a CAN remote frame with ID = 0x200 and DLC 
 Additionally, micro second time stamp is activated and is 15 us.
 
 
-## Timestamp
+## Timestamp and timing
 
 The timestamp attached to each frame represents the device up time.
 The milli second timestamp is taken after the CAN frame transmission/reception is complete, 

--- a/doc/4.-Reporting-Mechanism.md
+++ b/doc/4.-Reporting-Mechanism.md
@@ -9,7 +9,7 @@ When the device receives a CAN frame, it is notified in the same format as the t
 This function is enabled by default and can be disabled by `z` command.
 If disabled, the device will not send any data to the host even if it receives CAN frames.
 
-The Rx frame reporting is summarized in the table bellow.
+The Rx frame reporting is summarized in the table below.
 See the "Contents in a report" section for the details of `<Rx frame>`.
 
 | Rx frame reporting | Timing          | Message      |
@@ -23,7 +23,7 @@ Note:
 Example:
 - `t10020011[CR]`
 
-This message will be sent from the device when a classical CAN data frame with ID = 0x100 and 2 data bytes with the valued 0x00 and 0x11 is received.
+This message will be sent from the device when a classical CAN data frame with ID = 0x100 and 2 data bytes with the values 0x00 and 0x11 is received.
 
 
 # Tx event reporting
@@ -32,7 +32,7 @@ When the device transmits a CAN frame and it's acknowledged by another node, it 
 This function is disabled by default and can be enabled by `z` command.
 If disabled, the device responds with `z[CR]` or `Z[CR]` when the transmission command is in the correct format and successfully saved in the buffer without any reporting for a successful transmission.
 
-The Tx event reporting is summarized in the table bellow.
+The Tx event reporting is summarized in the table below.
 See the "Contents in a report" section for the details of `<Tx event>`.
 
 | Tx event reporting | Timing                             | Message            |
@@ -50,7 +50,7 @@ Note:
 Example:
 - `zt10020011[CR]`
 
-This message will be sent from the device when a classical CAN data frame with ID = 0x100 and 2 data bytes with the valued 0x00 and 0x11 is transmitted.
+This message will be sent from the device when a classical CAN data frame with ID = 0x100 and 2 data bytes with the values 0x00 and 0x11 is transmitted.
 
 
 # Contents in a report
@@ -72,7 +72,7 @@ Where `<z>` or `<Z>` is used for `<Tx event>`, `x` = `t` / `d` / `b`, `X` = `T` 
 Example 1:
 - `t10020011000A0[CR]`
 
-Denotes an incoming classical CAN data frame with ID = 0x100 and 2 data bytes with the valued 0x00 and 0x11.
+Denotes an incoming classical CAN data frame with ID = 0x100 and 2 data bytes with the values 0x00 and 0x11.
 Additionally, milli second time stamp is activated and is 10 ms and ESI is 0 = error active.
 
 Example 2:
@@ -92,4 +92,14 @@ If a CAN frame is re-transmitted, the reported timestamp corresponds to the fina
 When the time is queried directly using the `z[CR]` or `Z[CR]` command, 
 the returned value is obtained from the same source as the frame report.  
 
-TODO: Order between Rx and Tx report is not sorted.
+Note:
+- Rx frames are reported in chronological order relative to other Rx frames.
+- Tx events are reported in chronological order relative to other Tx events.
+- However, the relative order between an Rx frame report and a Tx event report is not guaranteed to be time-ordered.
+
+
+## Interaction between `z` and `Z` commands
+
+The `z` and `Z` commands are mutually exclusive: settings made by the `z` command will be overwritten when the `Z` command is issued, resetting the reporting configuration to the default.
+
+This behavior is intentional for backward compatibility. Classic host applications that support the `Z` command but not `z` can reset any `z`-based reporting configuration by issuing a `Z` command, restoring the device to a known state.

--- a/doc/5.-Hardware.md
+++ b/doc/5.-Hardware.md
@@ -19,7 +19,7 @@ The rules are applied from top.
 ### Startup
 
 * RDY: Constant ON
-* RX & TX: Blink 5 times in turn
+* RX & TX: Blink 5 times in total
 
 ### Error stored
 
@@ -37,3 +37,9 @@ The rules are applied from top.
 * RDY: Constant ON
 * RX: Blink by a CAN frame reception
 * TX: Blink by a CAN frame transmission
+
+
+# Hardware details
+
+For hardware-specific details such as connector pinout, termination resistor, and DB9 layout, refer to the original WeAct Studio hardware documentation:
+* https://github.com/WeActStudio/WeActStudio.USB2CANFDV1

--- a/doc/6.-Limitation.md
+++ b/doc/6.-Limitation.md
@@ -1,6 +1,6 @@
 # Protocol design
 
-There is no error‑detection mechanism such as a checksum or CRC in the LAWICAL protocol.
+There is no error‑detection mechanism such as a checksum or CRC in the LAWICEL protocol.
 If a message is truncated, it may cause unexpected device behavior or a misleading report.
 
 For example, while the device is reporting `t0003001122[CR]`, if the four characters `3001` are lost, then `t000122[CR]` is reported.
@@ -27,13 +27,13 @@ Also, enabling Tx event reporting will consume more throughput since it requires
 If you attempt to transmit or receive more data than this limit, you will encounter message loss.
 You can check for this loss using the `F` command.
 
-Properly filtering CAN frames with the `W`, `M` and `m` commands will help reduce message flow and ensure that all necessary data is received. Spliting roles into multiple deviced will also work (e.g., One device for Rx and another for Tx).
+Properly filtering CAN frames with the `W`, `M` and `m` commands will help reduce message flow and ensure that all necessary data is received. Splitting roles into multiple devices will also work (e.g., one device for Rx and another for Tx).
 
 If the required task does not fit in the capability of a device, you can:
 
 - Use multiple device and split roles to them (see the next section)
 - Switch to another device which supports High Speed USB
-- Switch to efficient binary protocol
+- Switch to an efficient binary protocol
 
 ### Load distribution
 

--- a/doc/7.-Buffer-Strategy.md
+++ b/doc/7.-Buffer-Strategy.md
@@ -1,8 +1,8 @@
 # Buffer strategy
 
-This project put reliability over performance.
-It would be better to delete whole message than passing corrupted data.
-A corrupted data may cause unexpected device behavior or deceiving report.
+This project puts reliability over performance.
+It is better to discard an entire message than to pass corrupted data.
+Corrupted data may cause unexpected device behavior or a misleading report.
 
 
 ## CDC Rx Buffer

--- a/doc/8.-Useful-Links.md
+++ b/doc/8.-Useful-Links.md
@@ -44,7 +44,7 @@ Clock accuracy
 * https://www.bosch-semiconductors.com/media/ip_modules/pdf_2/papers/icc14_2013_paper_mutter_1.pdf
 
 
-# STMG0 documents
+# STM32G0 documents
 
 ### STMicroelectronics
 UM2319

--- a/doc/LICENSE.md
+++ b/doc/LICENSE.md
@@ -1,1 +1,2 @@
-test
+Copyright (c) 2025-2026 NAKANISHI Kiyomaro
+All rights reserved.


### PR DESCRIPTION
Fixes documentation issues identified in the AI code review (issue #94).

**Changes per commit:**
- `doc/LICENSE.md`: Add copyright notice
- `doc/1.-Introduction.md`: Fix typos
- `doc/2.-Command-List.md`: Fix typos, improve origin wording, fix bit field numbering, add self-doc notes, fix W0 note
- `doc/3.-Acceptance-Filter.md`: Fix "conbined"
- `doc/4.-Reporting-Mechanism.md`: Fix typos, replace TODO, add z/Z compatibility note
- `doc/5.-Hardware.md`: Fix LED blink count, add hardware details reference
- `doc/6.-Limitation.md`: Fix typos
- `doc/7.-Buffer-Strategy.md`: Fix grammar
- `doc/8.-Useful-Links.md`: Fix STM32G0 heading

Closes #94

Generated with [Claude Code](https://claude.ai/code)