### PR TITLE
refactor: split slcan.h into generator.h and parser.h

### DIFF
--- a/usb2canfdv1-fw/App/Inc/generator.h
+++ b/usb2canfdv1-fw/App/Inc/generator.h
@@ -20,8 +20,10 @@
 // THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef USB2CANFDV1_SLCAN_H
-#define USB2CANFDV1_SLCAN_H
+#ifndef USB2CANFDV1_GENERATOR_H
+#define USB2CANFDV1_GENERATOR_H
+
+#include "stm32g0xx_hal.h"
 
 // Filter mode
 enum SlcanFilterMode
@@ -91,8 +93,6 @@ uint16_t slcan_generate_tx_event(uint8_t *buf, FDCAN_TxEventFifoTypeDef *tx_even
 uint16_t slcan_get_timestamp_ms(void);
 uint32_t slcan_get_timestamp_us_from_tim3(uint16_t tim3_us);
 
-void slcan_parse_str(uint8_t *buf, uint8_t len);
-
 HAL_StatusTypeDef slcan_set_filter_mode(enum SlcanFilterMode mode);
 HAL_StatusTypeDef slcan_set_filter_code(uint32_t code);
 HAL_StatusTypeDef slcan_set_filter_mask(uint32_t mask);
@@ -109,4 +109,4 @@ void slcan_raise_error(enum SlcanStatusFlag err);
 void slcan_clear_error(void);
 uint8_t slcan_get_status_flags(void);
 
-#endif // USB2CANFDV1_SLCAN_H
+#endif // USB2CANFDV1_GENERATOR_H

--- a/usb2canfdv1-fw/App/Inc/parser.h
+++ b/usb2canfdv1-fw/App/Inc/parser.h
@@ -1,0 +1,31 @@
+///////////////////////////////////////////////////////////////////////////////
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef USB2CANFDV1_PARSER_H
+#define USB2CANFDV1_PARSER_H
+
+#include "generator.h"
+
+// Prototypes
+void slcan_parse_str(uint8_t *buf, uint8_t len);
+
+#endif // USB2CANFDV1_PARSER_H

--- a/usb2canfdv1-fw/App/Src/buffer.c
+++ b/usb2canfdv1-fw/App/Src/buffer.c
@@ -26,7 +26,7 @@
 #include "buffer.h"
 #include "can.h"
 #include "led.h"
-#include "slcan.h"
+#include "parser.h"
 
 // Maximum number of frames between tail and send index
 // In one main loop, max. 3 frames can be sent, 1 tx event can be processed.

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -28,7 +28,7 @@
 #include "buffer.h"
 #include "can.h"
 #include "led.h"
-#include "slcan.h"
+#include "generator.h"
 
 // Bit number for each frame type WithOut Data bytes (from SOF to ITM)
 #define CAN_BIT_NBR_WOD_CBFF            47

--- a/usb2canfdv1-fw/App/Src/generator.c
+++ b/usb2canfdv1-fw/App/Src/generator.c
@@ -24,7 +24,7 @@
 
 #include "stm32g0xx_hal.h"
 #include "can.h"
-#include "slcan.h"
+#include "generator.h"
 
 // Public variables
 const uint8_t slcan_nibble_to_ascii[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};

--- a/usb2canfdv1-fw/App/Src/led.c
+++ b/usb2canfdv1-fw/App/Src/led.c
@@ -24,7 +24,7 @@
 
 #include "stm32g0xx_hal.h"
 #include "led.h"
-#include "slcan.h"
+#include "generator.h"
 
 // Duration in ms
 #define LED_BLINK_DURATION          (25)

--- a/usb2canfdv1-fw/App/Src/nvm.c
+++ b/usb2canfdv1-fw/App/Src/nvm.c
@@ -25,7 +25,7 @@
 #include "stm32g0xx_hal.h"
 #include "can.h"
 #include "nvm.h"
-#include "slcan.h"
+#include "generator.h"
 
 // Memory status
 enum NvmMemoryStatus

--- a/usb2canfdv1-fw/App/Src/parser.c
+++ b/usb2canfdv1-fw/App/Src/parser.c
@@ -29,7 +29,7 @@
 #include "can.h"
 #include "led.h"
 #include "nvm.h"
-#include "slcan.h"
+#include "parser.h"
 #ifdef DEBUG
 #include "bootloader.h"
 #endif

--- a/usb2canfdv1-fw/Core/Src/main.c
+++ b/usb2canfdv1-fw/Core/Src/main.c
@@ -31,7 +31,6 @@
 #include "can.h"
 #include "led.h"
 #include "nvm.h"
-#include "slcan.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/usb2canfdv1-fw/USB_Device/App/usbd_cdc_if.c
+++ b/usb2canfdv1-fw/USB_Device/App/usbd_cdc_if.c
@@ -23,7 +23,6 @@
 
 /* USER CODE BEGIN INCLUDE */
 #include "buffer.h"
-#include "slcan.h"
 /* USER CODE END INCLUDE */
 
 /* Private typedef -----------------------------------------------------------*/


### PR DESCRIPTION
Split `slcan.h` into dedicated `generator.h` and `parser.h` headers to make the generator/parser module boundary explicit, reduce unnecessary recompilation, and improve readability of the dependency graph.

Closes #103

Generated with [Claude Code](https://claude.ai/code)