### PR TITLE
feat: add sxxyy[CR] LAWICEL-compatible bit timing command

### DIFF
--- a/doc/2.-Command-List.md
+++ b/doc/2.-Command-List.md
@@ -8,7 +8,7 @@ CMD | STATE | SYNTAX                | DESCRIPTION                               
     |       |                       | S0 10kbps          S3 100kbps         S6 500kbps              |
     |       |                       | S1 20kbps          S4 125kbps         S7 800kbps              |
     |       |                       | S2 50kbps          S5 250kbps         S8 1Mbps                |
-'s' |  TODO |  sxxyy[CR]            | Sets up CAN nominal bit rate and bit timing,                  |    A
+'s' |  YES  |  sxxyy[CR]            | Sets up CAN nominal bit rate and bit timing,                  |    A
     |       |                       | where xx and yy are hex values.                               |
     |  YES  |  sddxxyyzz[CR]        | Sets up CAN FD nominal bit rate and bit timing,               |   DY
     |       |                       | where dd, xx, yy and zz are hex values.                       |
@@ -140,6 +140,38 @@ Note:
 - Though bit rate can be set with this command, it is recommended to use `s` and `y` commands for a proper bit timing.
 
 
+## sxxyy[CR]
+
+Sets up CAN nominal bit-rate and bit-timing in a LAWICEL-compatible manner, where `xx` and `yy` are hex values corresponding to the `BTR0` and `BTR1` registers of the SJA1000 CAN controller used by CAN232 / CANUSB.
+
+- `xx`    BTR0 value in hex (00 - FF)
+- `yy`    BTR1 value in hex (00 - FF)
+
+Bit fields of `xx` and `yy` are interpreted as on the SJA1000:
+
+- `Prescaler`         = `2 * ((xx & 0x3F) + 1)`       value in hex (02 - 80)
+- `Time seg1`         = `5 * (yy & 0x0F) + 9`          value in hex (09 - 54)
+- `Time seg2`         = `5 * ((yy >> 4) & 0x07) + 5`   value in hex (05 - 28)
+- `Sync jump width`   = `5 * ((xx >> 6) & 0x03) + 5`   value in hex (05 - 14)
+
+The factor `5` absorbs the clock ratio 80 MHz / 16 MHz, so the resulting bit rate and sample point match the original devices for the same `xx` and `yy` input.
+The `+9` bias of `Time seg1` absorbs the 4 tq excess from the SYNC segment.
+
+Precondition:
+- The CAN FD channel should be closed.
+
+Example:
+- `s031C[CR]`
+
+Sets up CAN nominal bit rate to 125kbps and sampling point to 87.5%. This is the default setting.
+
+Returns:
+- CR for OK or BELL for ERROR.
+
+Note:
+- The sampling mode bit (MSB of `yy`) is ignored; FDCAN always samples each bit once.
+
+
 ## sddxxyyzz[CR]
 
 Sets up CAN FD nominal bit-rates and bit-timing, where `dd`, `xx`, `yy` and `zz` are hex values.
@@ -153,9 +185,9 @@ Precondition:
 - The CAN FD channel should be closed.
 
 Example:
-- `s08460908[CR]`
+- `s08450A05[CR]`
 
-Sets up CAN FD nominal bit rate to 125kbps and sampling point to 88.75%.
+Sets up CAN FD nominal bit rate to 125kbps and sampling point to 87.5%.
 This is the default setting.
 
 See a bit timing calculator in the "Useful Links" page for the relationship between these parameters and bit rate and bit timing.

--- a/test/test_slcan.py
+++ b/test/test_slcan.py
@@ -193,6 +193,7 @@ class SlcanTestCase(unittest.TestCase):
 
 
     def test_s_command(self):
+        """Check response for the longer version of s command (sddxxyyzz[CR])"""
         # Check response with CAN port closed
         self.dut.send(b"s10460908\r")
         self.assertEqual(self.dut.receive(), b"\r")
@@ -247,6 +248,7 @@ class SlcanTestCase(unittest.TestCase):
 
 
     def test_sxxyy_command(self):
+        """Check response for the shorter version of s command (sxxyy[CR])"""
         # Check response with CAN port closed (default: 125kbps, 87.5% SP)
         self.dut.send(b"s031C\r")
         self.assertEqual(self.dut.receive(), b"\r")

--- a/test/test_slcan.py
+++ b/test/test_slcan.py
@@ -246,6 +246,66 @@ class SlcanTestCase(unittest.TestCase):
         self.assertEqual(self.dut.receive(), b"\a")
 
 
+    def test_sxxyy_command(self):
+        # Check response with CAN port closed (default: 125kbps, 87.5% SP)
+        self.dut.send(b"s031C\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+
+        # Check response in CAN normal mode
+        self.dut.send(b"O\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s031C\r")
+        self.assertEqual(self.dut.receive(), b"\a")
+        self.dut.send(b"C\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+
+        # Check response in CAN silent mode
+        self.dut.send(b"L\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s031C\r")
+        self.assertEqual(self.dut.receive(), b"\a")
+        self.dut.send(b"C\r")
+        self.assertEqual(self.dut.receive(), b"\r")
+
+        # Check standard LAWICEL bit rates (all use BTR1=0x1C for 87.5% SP)
+        self.dut.send(b"s311C\r")    # 10kbps
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s181C\r")    # 20kbps
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s091C\r")    # 50kbps
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s041C\r")    # 100kbps
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s011C\r")    # 250kbps
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s001C\r")    # 500kbps
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s0016\r")    # 800kbps
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s0014\r")    # 1Mbps
+        self.assertEqual(self.dut.receive(), b"\r")
+
+        # Check boundary values (all valid since formulas always produce in-range results)
+        self.dut.send(b"s0000\r")    # xx=0x00, yy=0x00 -> min values
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"sFFFF\r")    # xx=0xFF, yy=0xFF -> max values
+        self.assertEqual(self.dut.receive(), b"\r")
+
+        # Sampling mode bit (MSB of yy) is ignored
+        self.dut.send(b"s031C\r")    # yy=0x1C (bit7=0)
+        self.assertEqual(self.dut.receive(), b"\r")
+        self.dut.send(b"s039C\r")    # yy=0x9C (bit7=1, same timing)
+        self.assertEqual(self.dut.receive(), b"\r")
+
+        # Check invalid format
+        self.dut.send(b"s031\r")
+        self.assertEqual(self.dut.receive(), b"\a")
+        self.dut.send(b"s031C0\r")
+        self.assertEqual(self.dut.receive(), b"\a")
+        self.dut.send(b"s0G1C\r")
+        self.assertEqual(self.dut.receive(), b"\a")
+
+
     def test_Y_command(self):
         # Check response to Y with CAN port closed
         for idx in range(0, 10):

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -379,11 +379,12 @@ HAL_StatusTypeDef can_set_nominal_bitrate(enum CanBitrateNominal bitrate)
         return HAL_ERROR;
     }
 
-    // Set default bitrate 125k
+    // Set default bitrate 125kbps at 87.5% sampling point
+    // Equivalent to sxxyy command with BTR0=0x03, BTR1=0x1C
     can_bit_cfg_nominal.prescaler = 8;
-    can_bit_cfg_nominal.sjw = 8;
-    can_bit_cfg_nominal.time_seg1 = 70;
-    can_bit_cfg_nominal.time_seg2 = 9;
+    can_bit_cfg_nominal.sjw = 5;
+    can_bit_cfg_nominal.time_seg1 = 69;
+    can_bit_cfg_nominal.time_seg2 = 10;
 
     switch (bitrate)
     {
@@ -408,10 +409,11 @@ HAL_StatusTypeDef can_set_nominal_bitrate(enum CanBitrateNominal bitrate)
         can_bit_cfg_nominal.prescaler = 2;
         break;
     case CAN_BITRATE_800K:
+        // 87.5% is not achievable at 800kbps with 80MHz clock;
+        // use 87% (prescaler=1, N=100, SP=87/100) as the closest value.
         can_bit_cfg_nominal.prescaler = 1;
-        can_bit_cfg_nominal.sjw = 10;
-        can_bit_cfg_nominal.time_seg1 = 88;
-        can_bit_cfg_nominal.time_seg2 = 11;
+        can_bit_cfg_nominal.time_seg1 = 86;
+        can_bit_cfg_nominal.time_seg2 = 13;
         break;
     case CAN_BITRATE_1000K:
         can_bit_cfg_nominal.prescaler = 1;

--- a/usb2canfdv1-fw/App/Src/can.c
+++ b/usb2canfdv1-fw/App/Src/can.c
@@ -412,6 +412,7 @@ HAL_StatusTypeDef can_set_nominal_bitrate(enum CanBitrateNominal bitrate)
         // 87.5% is not achievable at 800kbps with 80MHz clock;
         // use 87% (prescaler=1, N=100, SP=87/100) as the closest value.
         can_bit_cfg_nominal.prescaler = 1;
+        can_bit_cfg_nominal.sjw = 7;
         can_bit_cfg_nominal.time_seg1 = 86;
         can_bit_cfg_nominal.time_seg2 = 13;
         break;

--- a/usb2canfdv1-fw/App/Src/parser.c
+++ b/usb2canfdv1-fw/App/Src/parser.c
@@ -439,6 +439,24 @@ void slcan_parse_str_set_bitrate(uint8_t *buf, uint8_t len)
         else
             buf_enqueue_cdc(SLCAN_RET_ERR, SLCAN_RET_LEN);
     }
+    else if (buf[0] == 's' && len == 5)
+    {
+        // sxxyy[CR]: LAWICEL-compatible BTR0/BTR1 register mapping
+        // xx = BTR0 (buf[1..2]), yy = BTR1 (buf[3..4])
+        uint8_t xx = ((uint8_t)buf[1] << 4) + buf[2];
+        uint8_t yy = ((uint8_t)buf[3] << 4) + buf[4];
+
+        struct CanBitrateCfg bitrate_cfg;
+        bitrate_cfg.prescaler = (uint16_t)(2 * ((xx & 0x3F) + 1));
+        bitrate_cfg.time_seg1 = (uint8_t)(5 * (yy & 0x0F) + 9);
+        bitrate_cfg.time_seg2 = (uint8_t)(5 * ((yy >> 4) & 0x07) + 5);
+        bitrate_cfg.sjw       = (uint8_t)(5 * ((xx >> 6) & 0x03) + 5);
+
+        if (can_set_nominal_bitrate_cfg(bitrate_cfg) == HAL_OK)
+            buf_enqueue_cdc(SLCAN_RET_OK, SLCAN_RET_LEN);
+        else
+            buf_enqueue_cdc(SLCAN_RET_ERR, SLCAN_RET_LEN);
+    }
     else if (buf[0] == 's' || buf[0] == 'y')
     {
         // Check for valid length

--- a/usb2canfdv1-fw/App/Src/parser.c
+++ b/usb2canfdv1-fw/App/Src/parser.c
@@ -417,7 +417,7 @@ void slcan_parse_str_close(uint8_t *buf, uint8_t len)
     return;
 }
 
-// Set nominal bitrate
+// Set nominal and data bitrate
 void slcan_parse_str_set_bitrate(uint8_t *buf, uint8_t len)
 {
     if (buf[0] == 'S' || buf[0] == 'Y')


### PR DESCRIPTION
Closes #63

## Summary

- Add `sxxyy[CR]` command that maps SJA1000 BTR0/BTR1 register values to FDCAN nominal bit timing (LAWICEL-compatible)
- Update default nominal sampling point from 88.75% to 87.5% for all `Sn` bit rates
- Add documentation and tests for the new command

## Test plan

- [x] Run `test_sxxyy_command` in test_slcan.py
- [x] Verify `s031C[CR]` produces 125 kbps at 87.5% sampling point
- [x] Verify `S4[CR]` now produces 125 kbps at 87.5% sampling point
- [x] Verify existing tests still pass

Generated with [Claude Code](https://claude.ai/code)