### PR TITLE
fix: disable flash prefetch to mitigate STM32G0B1 errata ES0548 §2.2.10

### DIFF
--- a/usb2canfdv1-fw/Core/Inc/stm32g0xx_hal_conf.h
+++ b/usb2canfdv1-fw/Core/Inc/stm32g0xx_hal_conf.h
@@ -178,7 +178,7 @@ in voltage and temperature.*/
 #define  VDD_VALUE                    (3300UL)                                        /*!< Value of VDD in mv */
 #define  TICK_INT_PRIORITY            3U /*!< tick interrupt priority */
 #define  USE_RTOS                     0U
-#define  PREFETCH_ENABLE              1U
+#define  PREFETCH_ENABLE              0U  /* Disabled: STM32G0B1 errata ES0548 §2.2.10 - prefetch failure across flash bank boundary */
 #define  INSTRUCTION_CACHE_ENABLE     1U
 
 /* ################## SPI peripheral configuration ########################## */


### PR DESCRIPTION
Set `PREFETCH_ENABLE` to `0U` in `stm32g0xx_hal_conf.h` to prevent prefetch failures when branching across the flash bank 1/2 boundary (0x08010000).

The app flash range can cross this boundary once the image exceeds ~38 KB, and with prefetch enabled this matches the errata trigger condition. Disabling prefetch has negligible performance impact for a CAN/CAN-FD bridge that is bus-speed bound.

Ref: ES0548 — STM32G0B1xB/xC/xE device errata, section 2.2.10

Closes #50

Generated with [Claude Code](https://claude.ai/code)