### PR TITLE
doc: add link to CAN hardware details

### DIFF
--- a/doc/5.-Hardware.md
+++ b/doc/5.-Hardware.md
@@ -43,3 +43,6 @@ The rules are applied from top.
 
 For hardware-specific details such as connector pinout, termination resistor, and DB9 layout, refer to the original WeAct Studio hardware documentation:
 * https://github.com/WeActStudio/WeActStudio.USB2CANFDV1
+
+For additional hardware details specific to this firmware, refer to:
+* https://github.com/Nakakiyo092/usb2canfdv1/discussions/42


### PR DESCRIPTION
Add link to the CAN hardware details discussion in 5.-Hardware.md.

Closes #130

Generated with [Claude Code](https://claude.ai/code)