### PR TITLE
Restrict ESI to FD frame forms in the report-format spec

### DIFF
--- a/doc/4.-Reporting-Mechanism.md
+++ b/doc/4.-Reporting-Mechanism.md
@@ -69,17 +69,21 @@ The following items can be added to them:
 - Error state indicator : ESI flag (0: Error active, 1: Error passive), configurable with `z` commands.
 
 Format:
-- `<z>riiil<tt...><e>[CR]` (Base remote frame)
-- `<Z>Riiiiiiiil<tt...><e>[CR]` (Extended remote frame)
-- `<z>xiiildd...<tt...><e>[CR]` (Base data frame)
-- `<Z>Xiiiiiiiildd...<tt...><e>[CR]` (Extended data frame)
+- `<z>riiil<tt...>[CR]` (Base remote frame)
+- `<Z>Riiiiiiiil<tt...>[CR]` (Extended remote frame)
+- `<z>tiiildd...<tt...>[CR]` (Base classical data frame)
+- `<Z>Tiiiiiiiildd...<tt...>[CR]` (Extended classical data frame)
+- `<z>diiildd...<tt...><e>[CR]` (Base FD data frame, no BRS)
+- `<Z>Diiiiiiiildd...<tt...><e>[CR]` (Extended FD data frame, no BRS)
+- `<z>biiildd...<tt...><e>[CR]` (Base FD data frame, with BRS)
+- `<Z>Biiiiiiiildd...<tt...><e>[CR]` (Extended FD data frame, with BRS)
 
-Where `<z>` or `<Z>` is used for `<Tx event>`, `x` = `t` / `d` / `b`, `X` = `T` / `D` / `B`, `<tt...>` is timestamp and `<e>` is ESI.
+Where `<z>` or `<Z>` is used for `<Tx event>`, `<tt...>` is timestamp and `<e>` is ESI. ESI is hardware state available only on CAN-FD frames, so it is appended exclusively to the FD data frame forms above — classical CAN data frames and remote frames carry no ESI.
 
 Example 1:
-- `t10020011000A0[CR]`
+- `d10020011000A0[CR]`
 
-Denotes an incoming classical CAN data frame with ID = 0x100 and 2 data bytes with the values 0x00 and 0x11.
+Denotes an incoming CAN-FD data frame (no BRS) with ID = 0x100 and 2 data bytes with the values 0x00 and 0x11.
 Additionally, milli second time stamp is activated and is 10 ms and ESI is 0 = error active.
 
 Example 2:


### PR DESCRIPTION
Closes #155 